### PR TITLE
TypeError when instantiating with api secret

### DIFF
--- a/nightscout/api.py
+++ b/nightscout/api.py
@@ -34,7 +34,7 @@ class Api(object):
             'Accept': 'application/json'
         }
         if self.api_secret:
-            headers['api-secret'] = hashlib.sha1(self.api_secret).hexdigest()
+            headers['api-secret'] = hashlib.sha1(self.api_secret.encode('utf-8')).hexdigest()
         return headers
 
     def get_sgvs(self, params={}):


### PR DESCRIPTION
When instantiated with api secret, hashing failed with: TypeError: Unicode-objects must be encoded before hashing.
```
/usr/local/lib/python3.6/dist-packages/python_nightscout-1.0.0-py3.6.egg/nightscout/api.py in request_headers(self)
     35         }
     36         if self.api_secret:
---> 37             headers['api-secret'] = hashlib.sha1(self.api_secret).hexdigest()
     38         return headers
     39 

TypeError: Unicode-objects must be encoded before hashing
```

 Added .encode(utf-8) to api_secret string.